### PR TITLE
update proc_macro2 to fix build with current nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.13.4"
 features = ["full"]
 
 [dependencies.proc-macro2]
-version = "0.3.8"
+version = "0.4.1"
 features = ["nightly"]
 
 [dev-dependencies]


### PR DESCRIPTION
This is the actual cause for my CI fails at https://github.com/ruma/ruma-client/pull/10 and https://github.com/ruma/ruma-api-macros/pull/2.
I noticed they were both the same error, and after `rustup update nightly`, I could reproduce those locally - they actually seem to have nothing to do with my changes itself, rebuilding master would fail as well.

Seems like this is enough, even though `quote` still depends on `proc_macro2` v0.3.8.