### PR TITLE
Add reverse conversion between http::Request/Response and generated Request/Response

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ features = ["nightly"]
 [dev-dependencies]
 futures = "0.1.21"
 http = "0.1.5"
+hyper = "0.12"
 serde = "1.0.57"
 serde_derive = "1.0.57"
 serde_json = "1.0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,26 +11,26 @@ repository = "https://github.com/ruma/ruma-api-macros"
 version = "0.2.2"
 
 [dependencies]
-quote = "0.5.2"
-ruma-api = "0.5.0"
+quote = "0.6"
+ruma-api = "0.5"
 
 [dependencies.syn]
-version = "0.13.10"
+version = "0.14"
 features = ["full"]
 
 [dependencies.proc-macro2]
-version = "0.4.2"
+version = "0.4"
 features = ["nightly"]
 
 [dev-dependencies]
-futures = "0.1.21"
-http = "0.1.5"
+futures = "0.1"
+http = "0.1"
 hyper = "0.12"
-serde = "1.0.57"
-serde_derive = "1.0.57"
-serde_json = "1.0.17"
-serde_urlencoded = "0.5.2"
-url = "1.7.0"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+serde_urlencoded = "0.5"
+url = "1.7"
 
 [lib]
 proc-macro = true

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -25,7 +25,7 @@ impl From<Vec<FieldValue>> for Metadata {
                 _ => panic!("expected Member::Named"),
             };
 
-            match identifier.as_ref() {
+            match identifier.to_string().as_ref() {
                 "description" => {
                     let expr_lit = match field_value.expr {
                         Expr::Lit(expr_lit) => expr_lit,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -343,7 +343,7 @@ impl ToTokens for Api {
             }
 
             impl ::futures::future::FutureFrom<::http::Request<::hyper::Body>> for Request {
-                type Future = Box<_Future<Item = Self, Error = Self::Error>>;
+                type Future = Box<_Future<Item = Self, Error = Self::Error> + Send>;
                 type Error = ::ruma_api::Error;
 
                 #[allow(unused_variables)]
@@ -405,12 +405,11 @@ impl ToTokens for Api {
             }
 
             impl ::futures::future::FutureFrom<::http::Response<::hyper::Body>> for Response {
-                type Future = Box<_Future<Item = Self, Error = Self::Error>>;
+                type Future = Box<_Future<Item = Self, Error = Self::Error> + Send>;
                 type Error = ::ruma_api::Error;
 
                 #[allow(unused_variables)]
-                fn future_from(http_response: ::http::Response<::hyper::Body>)
-                -> Box<_Future<Item = Self, Error = Self::Error>> {
+                fn future_from(http_response: ::http::Response<::hyper::Body>) -> Self::Future {
                     if http_response.status().is_success() {
                         #extract_response_headers
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,5 @@
-use quote::{ToTokens, Tokens};
+use proc_macro2::{Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
 use syn::synom::Synom;
 use syn::{Field, FieldValue, Ident, Meta};
@@ -23,7 +24,7 @@ pub fn strip_serde_attrs(field: &Field) -> Field {
             _ => return true,
         };
 
-        if meta_list.ident.as_ref() == "serde" {
+        if meta_list.ident == "serde" {
             return false;
         }
 
@@ -50,9 +51,9 @@ impl From<RawApi> for Api {
 }
 
 impl ToTokens for Api {
-    fn to_tokens(&self, tokens: &mut Tokens) {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
         let description = &self.metadata.description;
-        let method = Ident::from(self.metadata.method.as_ref());
+        let method = Ident::new(self.metadata.method.as_ref(), Span::call_site());
         let name = &self.metadata.name;
         let path = &self.metadata.path;
         let rate_limited = &self.metadata.rate_limited;
@@ -92,7 +93,7 @@ impl ToTokens for Api {
 
                 if segment.starts_with(':') {
                     let path_var = &segment[1..];
-                    let path_var_ident = Ident::from(path_var);
+                    let path_var_ident = Ident::new(path_var, Span::call_site());
 
                     tokens.append_all(quote! {
                         (&request_path.#path_var_ident.to_string());
@@ -122,7 +123,7 @@ impl ToTokens for Api {
                 url.set_query(Some(&::serde_urlencoded::to_string(request_query)?));
             }
         } else {
-            Tokens::new()
+            TokenStream::new()
         };
 
         let add_headers_to_request = if self.request.has_header_fields() {
@@ -134,11 +135,11 @@ impl ToTokens for Api {
 
             header_tokens
         } else {
-            Tokens::new()
+            TokenStream::new()
         };
 
         let create_http_request = if let Some(field) = self.request.newtype_body_field() {
-            let field_name = field.ident.expect("expected field to have an identifier");
+            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
 
             quote! {
                 let request_body = RequestBody(request.#field_name);
@@ -202,13 +203,13 @@ impl ToTokens for Api {
                 let mut headers = http_response.headers().clone();
             }
         } else {
-            Tokens::new()
+            TokenStream::new()
         };
 
         let response_init_fields = if self.response.has_fields() {
             self.response.init_fields()
         } else {
-            Tokens::new()
+            TokenStream::new()
         };
 
         tokens.append_all(quote! {

--- a/src/api/request.rs
+++ b/src/api/request.rs
@@ -181,7 +181,7 @@ impl ToTokens for Request {
             pub struct Request
         };
 
-        let request_struct_body = if self.fields.len() == 0 {
+        let request_struct_body = if self.fields.is_empty() {
             quote!(;)
         } else {
             let fields = self.fields.iter().fold(TokenStream::new(), |mut field_tokens, request_field| {

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -15,7 +15,7 @@ impl Response {
     }
 
     pub fn has_fields(&self) -> bool {
-        self.fields.len() != 0
+        !self.fields.is_empty()
     }
 
     pub fn has_header_fields(&self) -> bool {
@@ -142,7 +142,7 @@ impl From<Vec<Field>> for Response {
                     if has_newtype_body {
                         panic!("ruma_api! responses cannot have both normal body fields and a newtype body field");
                     } else {
-                        return ResponseField::Body(field);
+                        ResponseField::Body(field)
                     }
                 }
                 ResponseFieldKind::Header => ResponseField::Header(field, header.expect("missing header name")),
@@ -164,7 +164,7 @@ impl ToTokens for Response {
             pub struct Response
         };
 
-        let response_struct_body = if self.fields.len() == 0 {
+        let response_struct_body = if self.fields.is_empty() {
             quote!(;)
         } else {
             let fields = self.fields.iter().fold(TokenStream::new(), |mut fields_tokens, response_field| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 //! See the documentation for the `ruma_api!` macro for usage details.
 
 #![deny(missing_debug_implementations)]
-#![feature(proc_macro)]
 #![recursion_limit="256"]
 
 extern crate proc_macro;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 #![recursion_limit="256"]
 
 extern crate proc_macro;
+extern crate proc_macro2;
 #[macro_use] extern crate quote;
 extern crate ruma_api;
 #[macro_use] extern crate syn;
@@ -207,5 +208,5 @@ pub fn ruma_api(input: TokenStream) -> TokenStream {
 
     let api = Api::from(raw_api);
 
-    api.into_tokens().into()
+    api.into_token_stream().into()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@ mod api;
 ///
 /// extern crate futures;
 /// extern crate http;
+/// extern crate hyper;
 /// extern crate ruma_api;
 /// extern crate ruma_api_macros;
 /// extern crate serde;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ mod api;
 /// This will generate a `ruma_api::Metadata` value to be used for the `ruma_api::Endpoint`'s
 /// associated constant, single `Request` and `Response` structs, and the necessary trait
 /// implementations to convert the request into a `http::Request` and to create a response from a
-/// `http::Response`.
+/// `http::Response` and vice versa.
 ///
 /// The details of each of the three sections of the macros are documented below.
 ///
@@ -173,7 +173,7 @@ mod api;
 /// pub mod newtype_body_endpoint {
 ///     use ruma_api_macros::ruma_api;
 ///
-///     #[derive(Debug, Deserialize)]
+///     #[derive(Debug, Deserialize, Serialize)]
 ///     pub struct MyCustomType {
 ///         pub foo: String,
 ///     }

--- a/tests/ruma_api_macros.rs
+++ b/tests/ruma_api_macros.rs
@@ -1,4 +1,4 @@
-#![feature(proc_macro, try_from)]
+#![feature(try_from)]
 
 extern crate futures;
 extern crate http;

--- a/tests/ruma_api_macros.rs
+++ b/tests/ruma_api_macros.rs
@@ -2,6 +2,7 @@
 
 extern crate futures;
 extern crate http;
+extern crate hyper;
 extern crate ruma_api;
 extern crate ruma_api_macros;
 extern crate serde;


### PR DESCRIPTION
Requires changes in `ruma-api`: ruma/ruma-api#13
Depends on #7 (to avoid conflicts with it)

## The Issue
Currently `Endpoint::Request` can only be converted to `http::Request` (as required when building a Matrix client), however not the other way around (as required when building a Matrix server or, in my case, proxy). Same thing, other way around, for `Response`.

## Proposed Solution
This PR adds code to generate implementations for
- `::futures::future::FutureFrom<::http::Request<::hyper::Body>> for Request` and
- `::std::convert::TryFrom<Response> for ::http::Response<::hyper::Body>`.
The corresponding PR to `ruma-api` adds those traits to the associated types of `Endpoint`.

Additionally, this PR adds `Send` to the associated Future type of both generated FutureFrom implementations because I see really no reason why they shouldn't have it and it's required when they're used from within the new hyper server (since it's multi-threaded).