### PR TITLE
Use nested imports, update formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+merge_imports = true

--- a/src/api/metadata.rs
+++ b/src/api/metadata.rs
@@ -1,5 +1,4 @@
-use syn::punctuated::Pair;
-use syn::{Expr, FieldValue, Lit, Member};
+use syn::{punctuated::Pair, Expr, FieldValue, Lit, Member};
 
 pub struct Metadata {
     pub description: String,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,34 +1,40 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn::{braced, Field, FieldValue, Ident, Meta, Token};
-use syn::parse::{Parse, ParseStream, Result};
+use syn::{
+    braced,
+    parse::{Parse, ParseStream, Result},
+    Field, FieldValue, Ident, Meta, Token,
+};
 
 mod metadata;
 mod request;
 mod response;
 
-use self::metadata::Metadata;
-use self::request::Request;
-use self::response::Response;
+use self::{metadata::Metadata, request::Request, response::Response};
 
 pub fn strip_serde_attrs(field: &Field) -> Field {
     let mut field = field.clone();
 
-    field.attrs = field.attrs.into_iter().filter(|attr| {
-        let meta = attr.interpret_meta()
-            .expect("ruma_api! could not parse field attributes");
+    field.attrs = field
+        .attrs
+        .into_iter()
+        .filter(|attr| {
+            let meta = attr
+                .interpret_meta()
+                .expect("ruma_api! could not parse field attributes");
 
-        let meta_list = match meta {
-            Meta::List(meta_list) => meta_list,
-            _ => return true,
-        };
+            let meta_list = match meta {
+                Meta::List(meta_list) => meta_list,
+                _ => return true,
+            };
 
-        if &meta_list.ident.to_string() == "serde" {
-            return false;
-        }
+            if &meta_list.ident.to_string() == "serde" {
+                return false;
+            }
 
-        true
-    }).collect();
+            true
+        })
+        .collect();
 
     field
 }
@@ -200,7 +206,10 @@ impl ToTokens for Api {
         };
 
         let create_http_request = if let Some(field) = self.request.newtype_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let field_name = field
+                .ident
+                .as_ref()
+                .expect("expected field to have an identifier");
 
             quote! {
                 let request_body = RequestBody(request.#field_name);
@@ -239,7 +248,10 @@ impl ToTokens for Api {
         };
 
         let parse_request_body = if let Some(field) = self.request.newtype_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let field_name = field
+                .ident
+                .as_ref()
+                .expect("expected field to have an identifier");
 
             quote! {
                 #field_name: request_body,

--- a/src/api/response.rs
+++ b/src/api/response.rs
@@ -1,7 +1,6 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn::spanned::Spanned;
-use syn::{Field, Ident, Lit, Meta, NestedMeta};
+use syn::{spanned::Spanned, Field, Ident, Lit, Meta, NestedMeta};
 
 use api::strip_serde_attrs;
 
@@ -27,8 +26,10 @@ impl Response {
     }
 
     pub fn init_fields(&self) -> TokenStream {
-        let fields = self.fields.iter().map(|response_field| {
-            match *response_field {
+        let fields = self
+            .fields
+            .iter()
+            .map(|response_field| match *response_field {
                 ResponseField::Body(ref field) => {
                     let field_name = field
                         .ident
@@ -67,8 +68,7 @@ impl Response {
                         #field_name: response_body
                     }
                 }
-            }
-        });
+            });
 
         quote! {
             #(#fields,)*
@@ -78,7 +78,10 @@ impl Response {
     pub fn apply_header_fields(&self) -> TokenStream {
         let header_calls = self.fields.iter().filter_map(|response_field| {
             if let ResponseField::Header(ref field, ref header) = *response_field {
-                let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+                let field_name = field
+                    .ident
+                    .as_ref()
+                    .expect("expected field to have an identifier");
                 let header_name = Ident::new(header.as_ref(), Span::call_site());
                 let span = field.span();
 
@@ -97,13 +100,19 @@ impl Response {
 
     pub fn to_body(&self) -> TokenStream {
         if let Some(ref field) = self.newtype_body_field() {
-            let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+            let field_name = field
+                .ident
+                .as_ref()
+                .expect("expected field to have an identifier");
             let span = field.span();
             quote_spanned!(span=> response.#field_name)
         } else {
             let fields = self.fields.iter().filter_map(|response_field| {
                 if let ResponseField::Body(ref field) = *response_field {
-                    let field_name = field.ident.as_ref().expect("expected field to have an identifier");
+                    let field_name = field
+                        .ident
+                        .as_ref()
+                        .expect("expected field to have an identifier");
                     let span = field.span();
 
                     Some(quote_spanned! {span=>
@@ -126,7 +135,6 @@ impl Response {
         for response_field in self.fields.iter() {
             match *response_field {
                 ResponseField::NewtypeBody(ref field) => {
-
                     return Some(field);
                 }
                 _ => continue,
@@ -135,7 +143,6 @@ impl Response {
 
         None
     }
-
 }
 
 impl From<Vec<Field>> for Response {
@@ -210,9 +217,7 @@ impl From<Vec<Field>> for Response {
             }
         }).collect();
 
-        Response {
-            fields,
-        }
+        Response { fields }
     }
 }
 
@@ -254,15 +259,16 @@ impl ToTokens for Response {
                 struct ResponseBody(#ty);
             }
         } else if self.has_body_fields() {
-            let fields = self.fields.iter().filter_map(|response_field| {
-                match *response_field {
+            let fields = self
+                .fields
+                .iter()
+                .filter_map(|response_field| match *response_field {
                     ResponseField::Body(ref field) => {
                         let span = field.span();
                         Some(quote_spanned!(span=> #field))
                     }
                     _ => None,
-                }
-            });
+                });
 
             quote! {
                 /// Data in the response body.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,12 @@
 //! See the documentation for the `ruma_api!` macro for usage details.
 
 #![deny(missing_debug_implementations)]
-#![recursion_limit="256"]
+#![recursion_limit = "256"]
 
 extern crate proc_macro;
 extern crate proc_macro2;
-#[macro_use] extern crate quote;
+#[macro_use]
+extern crate quote;
 extern crate ruma_api;
 extern crate syn;
 

--- a/tests/ruma_api_macros.rs
+++ b/tests/ruma_api_macros.rs
@@ -6,7 +6,8 @@ extern crate hyper;
 extern crate ruma_api;
 extern crate ruma_api_macros;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_urlencoded;
 extern crate url;


### PR DESCRIPTION
Like the other nested import PR's, only that for ruma-api-macros, a few places were affected by (semi-)recent rustfmt changes apparently. `cargo +stable fmt` doesn't revert any of the changes (the import grouping needs to be done with nightly `rustfmt` currently because `merge_imports` is still unstable).